### PR TITLE
Add PHP ODBC driver configuration for php-nginx image

### DIFF
--- a/phpnginx/Dockerfile
+++ b/phpnginx/Dockerfile
@@ -15,7 +15,8 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && \
     apt-get install -y --force-yes nginx \
     php5-fpm php5-cli php5-mysql php5-mcrypt \
-    php5-curl php5-gd php5-intl && \
+    php5-curl php5-gd php5-intl \
+    unixODBC-dev php5-odbc && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* \
            /tmp/* \
@@ -49,3 +50,13 @@ VOLUME ["/var/www", "/etc/nginx/sites-available", "/etc/nginx/sites-enabled"]
 WORKDIR /var/www
 
 EXPOSE 80
+
+# Configure odbc
+FROM php
+RUN apt-get update && apt-get install -y unixODBC-dev && rm -rf /var/lib/apt/lists/*
+RUN set -x \
+    && cd /usr/src/php/ext/odbc \
+    && phpize \
+    && sed -ri 's@^ *test +"\$PHP_.*" *= *"no" *&& *PHP_.*=yes *$@#&@g' configure \
+    && ./configure --with-unixODBC=shared,/usr \
+    && docker-php-ext-install odbc


### PR DESCRIPTION
## Description

This change allows for **unixODBC** driver to be installed alongside all php dependencies in php-nginx image, further expanding the available OOTB dependencies offered by LaraDock. 

It also takes into account docker-library configuration issues for php-odbc driver (see **#https://github.com/docker-library/php/issues/103**).
## Status

**READY**
