### PR TITLE
Specify version for php-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,8 @@ RUN apt-get update && \
         php7.0-bcmath \
         php7.0-memcached \
         php7.0-gd \
+        php7.0-dev \
         pkg-config \
-        php-dev \
         libcurl4-openssl-dev \
         libedit-dev \
         libssl-dev \

--- a/Dockerfile-71
+++ b/Dockerfile-71
@@ -44,8 +44,8 @@ RUN apt-get update && \
         php7.1-zip \
         php7.1-memcached \
         php7.1-gd \
+        php7.1-dev \
         pkg-config \
-        php-dev \
         libcurl4-openssl-dev \
         libedit-dev \
         libssl-dev \


### PR DESCRIPTION
This is a bug I just ran into. If you don't specify the version for `php-dev`, it'll pull dependencies for the LATEST version of PHP, in this case right now, the latest is PHP 7.1, meaning it'll install both PHP 7.0 (as specified for other packages such as `php7.0-cli`) and PHP 7.1 (the latest as per `php-dev`), which is not correct. Simply specifying the version for every single package installed is the solution, and `php-dev` was the only one that didn't. Changing to `php7.0-dev` fixes the issue.