### PR TITLE
upgrade ubuntu from 16 to 18

### DIFF
--- a/Dockerfile-56
+++ b/Dockerfile-56
@@ -4,7 +4,7 @@
 #--------------------------------------------------------------------------
 #
 
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:0.11
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 

--- a/Dockerfile-70
+++ b/Dockerfile-70
@@ -4,7 +4,7 @@
 #--------------------------------------------------------------------------
 #
 
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:0.11
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 

--- a/Dockerfile-71
+++ b/Dockerfile-71
@@ -4,7 +4,7 @@
 #--------------------------------------------------------------------------
 #
 
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:0.11
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 

--- a/Dockerfile-72
+++ b/Dockerfile-72
@@ -4,7 +4,7 @@
 #--------------------------------------------------------------------------
 #
 
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:0.11
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 

--- a/Dockerfile-73
+++ b/Dockerfile-73
@@ -4,7 +4,7 @@
 #--------------------------------------------------------------------------
 #
 
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:0.11
 
 LABEL maintainer="Mahmoud Zalt <mahmoud@zalt.me>"
 


### PR DESCRIPTION
Update the base image to use Ubuntu 18.04 LTS and use a specific version to help ensure reproducibility.

https://github.com/phusion/baseimage-docker/issues/467#issuecomment-491460845