### PR TITLE
Add 'tree' command to the image

### DIFF
--- a/Dockerfile-56
+++ b/Dockerfile-56
@@ -64,6 +64,7 @@ RUN apt-get update && \
         curl \
         vim \
         nano \
+        tree \
         postgresql-client \
     && apt-get clean
 

--- a/Dockerfile-70
+++ b/Dockerfile-70
@@ -64,6 +64,7 @@ RUN apt-get update && \
         curl \
         vim \
         nano \
+        tree \
         postgresql-client \
     && apt-get clean
 

--- a/Dockerfile-71
+++ b/Dockerfile-71
@@ -64,6 +64,7 @@ RUN apt-get update && \
         curl \
         vim \
         nano \
+        tree \
         postgresql-client \
     && apt-get clean
 

--- a/Dockerfile-72
+++ b/Dockerfile-72
@@ -63,6 +63,7 @@ RUN apt-get update && \
         curl \
         vim \
         nano \
+        tree \
         postgresql-client \
     && apt-get clean
 

--- a/Dockerfile-73
+++ b/Dockerfile-73
@@ -63,6 +63,7 @@ RUN apt-get update && \
         curl \
         vim \
         nano \
+        tree \
         postgresql-client \
     && apt-get clean
 

--- a/Dockerfile-74
+++ b/Dockerfile-74
@@ -63,6 +63,7 @@ RUN apt-get update && \
         curl \
         vim \
         nano \
+        tree \
         postgresql-client \
     && apt-get clean
 


### PR DESCRIPTION
This change is the first step of a two way fix in order to fix the `tre` alias.

See laradock/laradock#2734