### PR TITLE
Ensure that correct PHP version is symlinked

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -42,7 +42,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to Docker Hub
-        if: ${{ (github.repository == 'laradock/workspace') }}
+        if: ${{ (github.repository == 'laradock/workspace') && (github.ref == 'refs/heads/master') }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
@@ -53,5 +53,5 @@ jobs:
         with:
           file: Dockerfile-${{ matrix.php_version }}
           platforms: linux/amd64,linux/arm64,linux/386
-          push: ${{ (github.repository == 'laradock/workspace') }}
+          push: ${{ (github.repository == 'laradock/workspace') && (github.ref == 'refs/heads/master') }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile-8.0
+++ b/Dockerfile-8.0
@@ -63,6 +63,7 @@ RUN set -eux \
         tree \
         postgresql-client \
     && apt-get clean \
+    && update-alternatives --set php /usr/bin/php8.0 \
     #####################################
     # Composer:
     #####################################


### PR DESCRIPTION
This PR fixes https://github.com/laradock/laradock/issues/3133 by ensuring that the correct PHP version is symlinked. As noted in [my comment on the issue](https://github.com/laradock/laradock/issues/3133#issuecomment-1032944010) it seems that there is an indirect dependency on PHP 8.1 during the installation of the PHP 8.0 packages. This causes both PHP 8.0 and PHP 8.1 to be installed, and for 8.1 to take priority in the `php` virtual package. The fix in this PR re-sets the virtual package to use PHP 8.0 instead, which then restores the image's expected behaviour.

This issue seems to be affecting the [CI job](https://github.com/laradock/laradock/runs/5080664378) for testing the build of PHP 8.0 workspace, so this fix should resolve that failure. It looks like this issue could also be affecting the other workspace jobs for previous PHP versions, however I haven't been able to validate that locally. If this is the case, I imagine that a similar fix in each of the previous Dockerfile's could resolve that too (ie. in `Dockerfile-7.4`: `update-alternatives --set php /usr/bin/php7.4`, etc).

I suppose that this fix could instead be applied in [laradock/laradock](https://github.com/laradock/laradock)'s `workspace/Dockerfile` as `RUN update-alternatives --set php /usr/bin/php${LARADOCK_PHP_VERSION}` - however, as it seems a more fundamental fix I figured it might be better placed here in the base image itself.

Please feel free to amend this PR as necessary.