### PR TITLE
Use GitHub Actions V4

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -18,7 +18,7 @@ jobs:
         php_version: ["5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
Bump GitHub Actions to V4
[actions/checkout/releases/v4.0.0](https://github.com/actions/checkout/releases/tag/v4.0.0)